### PR TITLE
Fix moving or short contentLayer.

### DIFF
--- a/css/hamburger.css
+++ b/css/hamburger.css
@@ -134,7 +134,7 @@ so that the content is unclickable while menu is shown
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    position: absolute;
+    position: fixed;
     right: 0;
     top: 0;
     width: 30%;


### PR DESCRIPTION
To reproduce this, you can make the \<nav\> visible before scrolling the #content \<div\>. 

This is visible when testing with Firefox 41.0.2 and Chrome 46.0.2490.80 (64-bit) on Mac OS X 10.11.1. Admittedly, I have not tested this on a mobile device, but I would imagine the intention is that this should still work when viewed on a desktop. 

Attached is an animated GIF that should show an example of this. 

![contentlayer not moving](https://cloud.githubusercontent.com/assets/142929/11022657/ef031428-8618-11e5-868c-fa0fbb9e8369.gif)

Another situation--the more obvious one--is where your \<div id="content"\> contains several items (images, in this example) that exceed the viewport height and requires scrolling to view the contents. Attached is another animated GIF to demonstrate.

![contentlayer doesn t move](https://cloud.githubusercontent.com/assets/142929/11022655/e4d33aa0-8618-11e5-8e1c-6ee517c9faec.gif)

This is more easily visible if you were to change the background-color to something visible, such as red. 


